### PR TITLE
s/current/compare

### DIFF
--- a/markdown-changelog.el
+++ b/markdown-changelog.el
@@ -82,7 +82,7 @@ If the version can not be determined, return DEFAULT or raise an error."
   (interactive "sProject URL: ")
   (if (string-match "\\/$" url)
       (setq url (substring url 0 (1- (length url)))))
-  (setq url (format "%s/current/" url))
+  (setq url (format "%s/compare/" url))
   (let ((first-content (-> "\
 # Change Log
 


### PR DESCRIPTION
as far I know the current URL resource does not exists on github.

items should have this format:
[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2